### PR TITLE
Edge-Case Handling for Württemberger Schachthydranten

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -191,6 +191,10 @@
             label += ' ' + item.tags['diameter'] + ' mm'
         }
 
+        if (item.tags['fire_hydrant:style']) {
+            label += ' (' + item.tags['fire_hydrant:style'] + ')';
+        }
+
         if (item.tags['fire_hydrant:position']) {
             switch (item.tags['fire_hydrant:position']) {
                 case 'lane':


### PR DESCRIPTION
Hello,

first of all thanks for the amazing open source project, the website is really useful!

Disclaimer:
I have not yet tested whether the changes work in production. As I have no experience with Svelte and web-development in general, I first have to dig into that.

I am from the southern part of Baden-Württemberg, where we unfortunately have two types of underground hydrants. Besides the normal ones, there are so-called "Württemberger Schachthydranten" (see [here](https://de.wikipedia.org/wiki/W%C3%BCrttemberger_Schachthydrant)). These are located deeper than normal hydrants and thus require a different (longer) attachment pipe. 
OpenStreetMap covers the edge-case via a separate style entry ([Section "Besondere Baumformen"](https://wiki.openstreetmap.org/wiki/DE:Tag:emergency=fire_hydrant)).

Based on my current understanding it seems like this edge-case is currently not yet handled within the visualization. Hence, I added it next to the diameter. What do you think about this change? Is there a better place to display the information? If so, please feel free to hijack the MR 😄 
Changing the WSH entry to upper-case letters may better suit the style of the remaining label, however, that felt a bit risky given that I didn't check the code in production.

